### PR TITLE
Fix issue caused by Python 3 version including a letter.

### DIFF
--- a/hitch/commandline.py
+++ b/hitch/commandline.py
@@ -66,8 +66,10 @@ def init(python, virtualenv):
             stderr.write("{0} not found.\n".format(python))
             exit(1)
 
-    str_version = check_output([python3, "-V"], stderr=STDOUT).decode('utf8').replace('\n', '')
-    tuple_version = tuple([int(v) for v in str_version.replace('Python ', '').split('.')])
+    python_version = check_output([python3, "-V"], stderr=STDOUT).decode('utf8')
+    replacements = ('Python ', ''), ('\n', '')
+    str_version = reduce(lambda a, kv: a.replace(*kv), replacements, python_version)
+    tuple_version = tuple([int(x) for x in str_version.split('.')[:2]])
 
     if tuple_version < (3, 3):
         stderr.write(languagestrings.YOU_MUST_HAVE_VERSION_ABOVE_PYTHON33)


### PR DESCRIPTION
When the Python 3 version contains a letter (such as 'Python 3.5.0a1') it results in a the following:

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/bin/hitch", line 11, in <module>
    sys.exit(commandline.run())
  File "/usr/local/lib/python2.7/site-packages/hitch/commandline.py", line 307, in run
    cli()
  File "/usr/local/lib/python2.7/site-packages/hitch/click/core.py", line 719, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/hitch/click/core.py", line 699, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/hitch/click/core.py", line 1046, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/hitch/click/core.py", line 892, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/hitch/click/core.py", line 527, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/hitch/commandline.py", line 71, in init
    tuple_version = tuple([int(v) for v in str_version.replace('Python ', '').split('.')])
ValueError: invalid literal for int() with base 10: '0a1'
```

This PR reduces the check to the major and minor version numbers.
